### PR TITLE
Add ability to listen to theme switched event.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,16 @@ webpackConfig.externals = {
 ```
 
 This would allow your package to depends on `laravel-nova` from external source and no longer compiled it locally. 
+
+### Theme Switched Event
+
+Instead of manually registering custom `MutationObserver` on each package, you can now listen to a single `nova-theme-switched` event:
+
+```js
+Nova.$on('nova-theme-switched', ({ theme, element }) => {
+  if (theme === 'dark') {
+    element.add('package-dark')
+  } else {
+    element.remove('package-dark)
+  }
+})

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Nova.$on('nova-theme-switched', ({ theme, element }) => {
   if (theme === 'dark') {
     element.add('package-dark')
   } else {
-    element.remove('package-dark)
+    element.remove('package-dark')
   }
 })
+```

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     },
     "require": {
         "php": "^7.3 || ^8.0",
-        "laravel/nova": ">=4.13.0 <4.15.0"
+        "laravel/nova": ">=4.13.0 <4.14.0"
     },
     "require-dev": {
         "orchestra/testbench": "^6.24 || ^7.0"
@@ -29,7 +29,7 @@
     ],
     "extra": {
         "branch-alias": {
-            "dev-main": "1.2.x-dev"
+            "dev-main": "1.3.x-dev"
         },
         "laravel": {
             "providers": [

--- a/resources/js/tool.js
+++ b/resources/js/tool.js
@@ -5,7 +5,7 @@ Nova.booting(() => {
     const element = document.documentElement.classList
     const theme = element.contains('dark') ? 'light' : 'dark'
 
-    Nova.$emit('package: theme-switched', {
+    Nova.$emit('nova-theme-switched', {
       theme,
       element
     })

--- a/resources/js/tool.js
+++ b/resources/js/tool.js
@@ -1,6 +1,6 @@
 window.LaravelNova = require('laravel-nova')
 
-Nova.booting(app => {
+Nova.booting(() => {
   new MutationObserver(() => {
     const element = document.documentElement.classList
     const theme = element.contains('dark') ? 'light' : 'dark'

--- a/resources/js/tool.js
+++ b/resources/js/tool.js
@@ -1,1 +1,17 @@
 window.LaravelNova = require('laravel-nova')
+
+Nova.booting(app => {
+  new MutationObserver(() => {
+    const element = document.documentElement.classList
+    const theme = element.contains('dark') ? 'light' : 'dark'
+
+    Nova.$emit('package: theme-switched', {
+      theme,
+      element
+    })
+  }).observe(document.documentElement, {
+    attributes: true,
+    attributeOldValue: true,
+    attributeFilter: ['class'],
+  })
+})


### PR DESCRIPTION
Usage example:

```js
Nova.$on('nova-theme-switched', ({ theme, element }) => {
  if (theme === 'dark') {
    element.add('package-dark')
  } else {
    element.remove('package-dark')
  }
})
```