### PR TITLE
Allow install on nova 4.19

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     },
     "require": {
         "php": "^7.3 || ^8.0",
-        "laravel/nova": ">=4.16.0 <4.19.0"
+        "laravel/nova": ">=4.16.0 <4.20.0"
     },
     "require-dev": {
         "orchestra/testbench": "^6.24 || ^7.0"


### PR DESCRIPTION
Nova 4.19 is out but this package prevent us from updating to it.