### PR TITLE
Nova 4.22.0 support 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     },
     "require": {
         "php": "^7.3 || ^8.0",
-        "laravel/nova": ">=4.19.0 <4.22.0"
+        "laravel/nova": ">=4.22.0 <4.23.0"
     },
     "require-dev": {
         "orchestra/testbench": "^6.24 || ^7.0"

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "laravel/nova": ">=4.22.0 <4.23.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^6.24 || ^7.0"
+        "orchestra/testbench": "^6.24 || ^7.0 || ^8.0"
     },
     "repositories": [
         {


### PR DESCRIPTION
```
### Changes

* Add support for Laravel Nova 4.22.0+.
* Laravel Framework `v10` support.

#### Added

* New `HandlesFieldAttachments` mixin.

#### Changes

* Change `FormField` to trigger `setInitialValue()` from `created()` hook instead of the original `mounted()` hook.

```