### PR TITLE
 Nova 4.26.0 support 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     },
     "require": {
         "php": "^7.3 || ^8.0",
-        "laravel/nova": ">=4.25.0 <4.27.0"
+        "laravel/nova": ">=4.26.0 <4.27.0"
     },
     "require-dev": {
         "orchestra/testbench": "^6.24 || ^7.0 || ^8.0"


### PR DESCRIPTION
```markdown
### Changes

* Support Laravel Nova between 4.26.0+.

#### Added

* Added support for `{ openInNewTab: true }` options via `Nova.visit()`


#### Changes

* Bump CodeMirror to `5.65.13`.
* Utilise `this.fieldAttribute` computed instead of `this.field.attribute`
```